### PR TITLE
Replace HTTParty with Net::HTTP for persistent connections and configurable timeout

### DIFF
--- a/airtable.gemspec
+++ b/airtable.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'httparty', '>= 0.24.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.7.2'
-  spec.add_development_dependency 'minitest', '~> 5.6.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'minitest', '~> 5.25'
+  spec.add_development_dependency 'mutex_m'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'webmock', '~> 2.1.0'
+  spec.add_development_dependency 'webmock', '~> 3.24'
 end

--- a/airtable.gemspec
+++ b/airtable.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activesupport', '>= 3.0'
-  spec.add_dependency 'httparty', '>= 0.24.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.25'

--- a/lib/airtable.rb
+++ b/lib/airtable.rb
@@ -1,4 +1,7 @@
-require 'httparty'
+require 'net/http'
+require 'json'
+require 'uri'
+require 'openssl'
 require 'delegate'
 require 'active_support/core_ext/hash'
 

--- a/lib/airtable/client.rb
+++ b/lib/airtable/client.rb
@@ -8,13 +8,14 @@
 
 module Airtable
   class Client
-    def initialize(api_key)
+    def initialize(api_key, timeout: Resource::DEFAULT_TIMEOUT)
       @api_key = api_key
+      @timeout = timeout
     end
 
     # table("appXXV84QuCy2BPgLk", "Sheet Name")
     def table(app_token, worksheet_name)
-      Table.new(@api_key, app_token, worksheet_name)
+      Table.new(@api_key, app_token, worksheet_name, timeout: @timeout)
     end
-  end # Client
-end # Airtable
+  end
+end

--- a/lib/airtable/resource.rb
+++ b/lib/airtable/resource.rb
@@ -27,6 +27,7 @@ module Airtable
     end
 
     def build_connection
+      reused = !@connection.nil?
       uri = URI(BASE_URI)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
@@ -35,6 +36,7 @@ module Airtable
       http.write_timeout = @timeout
       http.keep_alive_timeout = 30
       http.start
+      log_connection(reused ? :reconnected : :opened)
       http
     end
 
@@ -46,6 +48,7 @@ module Airtable
 
     def close_connection
       @connection&.finish if connection_active?
+      log_connection(:closed)
     rescue IOError
       # already closed
     ensure
@@ -55,12 +58,37 @@ module Airtable
     def perform_request(request)
       retries = 0
       begin
-        connection.request(request)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        response = connection.request(request)
+        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) * 1000).round
+        @last_request_duration_ms = duration_ms
+        @last_request_body_size = request.body&.bytesize || 0
+        @last_response_body_size = response.body&.bytesize || 0
+        response
       rescue IOError, Errno::ECONNRESET, Errno::EPIPE, OpenSSL::SSL::SSLError => e
         close_connection
         retries += 1
-        retry if retries <= 1
+        if retries <= 1
+          log_retry(request, e)
+          retry
+        end
         raise e
+      end
+    end
+
+    def log_retry(request, error)
+      message = "[Airtable] Connection reset (#{error.class}: #{error.message}), retrying #{request.method} #{worksheet_name}"
+      if defined?(Rails)
+        Rails.logger.warn(message)
+      else
+        $stderr.puts(message)
+      end
+    end
+
+    def log_connection(event)
+      message = "[Airtable] Connection #{event} for #{worksheet_name}"
+      if defined?(Rails)
+        Rails.logger.debug(message)
       end
     end
 

--- a/lib/airtable/resource.rb
+++ b/lib/airtable/resource.rb
@@ -1,17 +1,112 @@
 module Airtable
-  # Base class for authorized resources sending network requests
+  # Base class for authorised resources sending network requests.
+  #
+  # Each Table instance holds its own persistent connection to the Airtable
+  # API. Table instances must not be shared across threads.
   class Resource
-    include HTTParty
-    base_uri 'https://api.airtable.com/v0/'
-    # debug_output $stdout
+    BASE_URI = 'https://api.airtable.com'
+    BASE_PATH = '/v0'
+    DEFAULT_TIMEOUT = 30
 
     attr_reader :api_key, :app_token, :worksheet_name
 
-    def initialize(api_key, app_token, worksheet_name)
+    def initialize(api_key, app_token, worksheet_name, timeout: DEFAULT_TIMEOUT)
       @api_key = api_key
       @app_token = app_token
       @worksheet_name = worksheet_name
-      self.class.headers({'Authorization' => "Bearer #{@api_key}"})
+      @timeout = timeout
     end
-  end # AuthorizedResource
-end # Airtable
+
+    private
+
+    def connection
+      if @connection.nil? || !connection_active?
+        @connection = build_connection
+      end
+      @connection
+    end
+
+    def build_connection
+      uri = URI(BASE_URI)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = @timeout
+      http.read_timeout = @timeout
+      http.write_timeout = @timeout
+      http.keep_alive_timeout = 30
+      http.start
+      http
+    end
+
+    def connection_active?
+      @connection&.started?
+    rescue IOError
+      false
+    end
+
+    def close_connection
+      @connection&.finish if connection_active?
+    rescue IOError
+      # already closed
+    ensure
+      @connection = nil
+    end
+
+    def perform_request(request)
+      retries = 0
+      begin
+        connection.request(request)
+      rescue IOError, Errno::ECONNRESET, Errno::EPIPE, OpenSSL::SSL::SSLError => e
+        close_connection
+        retries += 1
+        retry if retries <= 1
+        raise e
+      end
+    end
+
+    def default_headers
+      {
+        'Authorization' => "Bearer #{@api_key}",
+        'Content-Type' => 'application/json'
+      }
+    end
+
+    def build_get_request(path, query: nil)
+      full_path = query ? "#{path}?#{encode_query(query)}" : path
+      request = Net::HTTP::Get.new(full_path)
+      default_headers.each { |key, value| request[key] = value }
+      request
+    end
+
+    def build_post_request(path, body:)
+      request = Net::HTTP::Post.new(path)
+      default_headers.each { |key, value| request[key] = value }
+      request.body = body.to_json
+      request
+    end
+
+    def build_put_request(path, body:)
+      request = Net::HTTP::Put.new(path)
+      default_headers.each { |key, value| request[key] = value }
+      request.body = body.to_json
+      request
+    end
+
+    def build_patch_request(path, body:)
+      request = Net::HTTP::Patch.new(path)
+      default_headers.each { |key, value| request[key] = value }
+      request.body = body.to_json
+      request
+    end
+
+    def build_delete_request(path)
+      request = Net::HTTP::Delete.new(path)
+      default_headers.each { |key, value| request[key] = value }
+      request
+    end
+
+    def encode_query(params)
+      params.map { |key, value| "#{URI.encode_www_form_component(key.to_s)}=#{URI.encode_www_form_component(value.to_s)}" }.join('&')
+    end
+  end
+end

--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -1,7 +1,6 @@
 module Airtable
 
   class Table < Resource
-    # Maximum results per request
     LIMIT_MAX = 100
 
     # Fetch all records iterating through offsets until retrieving the entire collection
@@ -23,11 +22,12 @@ module Airtable
     # records(:sort => ["Name", :desc], :limit => 50, :offset => "as345g")
     def records(options={})
       options["sortField"], options["sortDirection"] = options.delete(:sort) if options[:sort]
-      response = self.class.get(worksheet_url, query: options)
-      log_request(response, 'GET')
-      results = response.parsed_response
-      check_and_raise_error(results, status_code: response.code)
-      RecordSet.new(results)
+      request = build_get_request(worksheet_url, query: options)
+      response = perform_request(request)
+      log_response(response, 'GET')
+      result = parse_response(response)
+      check_and_raise_error(result, status_code: response.code.to_i)
+      RecordSet.new(result)
     end
 
     # Query for records using a string formula
@@ -44,11 +44,12 @@ module Airtable
         options['filterByFormula'] = options.delete(:formula)
       end
 
-      response = self.class.get(worksheet_url, query: options)
-      log_request(response, 'GET')
-      results = response.parsed_response
-      check_and_raise_error(results, status_code: response.code)
-      RecordSet.new(results)
+      request = build_get_request(worksheet_url, query: options)
+      response = perform_request(request)
+      log_response(response, 'GET')
+      result = parse_response(response)
+      check_and_raise_error(result, status_code: response.code.to_i)
+      RecordSet.new(result)
     end
 
     def raise_bad_formula_error
@@ -57,22 +58,22 @@ module Airtable
 
     # Returns record based given row id
     def find(id)
-      response = self.class.get(worksheet_url + "/" + id)
-      log_request(response, 'GET')
-      result = response.parsed_response
-      check_and_raise_error(result, status_code: response.code)
+      request = build_get_request("#{worksheet_url}/#{id}")
+      response = perform_request(request)
+      log_response(response, 'GET')
+      result = parse_response(response)
+      check_and_raise_error(result, status_code: response.code.to_i)
       Record.new(result_attributes(result)) if result.present? && result["id"]
     end
 
     # Creates a record by posting to airtable
     def create(record)
-      response = self.class.post(worksheet_url,
-        :body => { "fields" => record.fields }.to_json,
-        :headers => { "Content-type" => "application/json" })
-      log_request(response, 'POST')
-      result = response.parsed_response
+      request = build_post_request(worksheet_url, body: { "fields" => record.fields })
+      response = perform_request(request)
+      log_response(response, 'POST')
+      result = parse_response(response)
 
-      check_and_raise_error(result, status_code: response.code)
+      check_and_raise_error(result, status_code: response.code.to_i)
 
       record.override_attributes!(result_attributes(result))
       record
@@ -80,61 +81,77 @@ module Airtable
 
     # Replaces record in airtable based on id
     def update(record)
-      response = self.class.put(worksheet_url + "/" + record.id,
-        :body => { "fields" => record.fields_for_update }.to_json,
-        :headers => { "Content-type" => "application/json" })
-      log_request(response, 'PUT')
-      result = response.parsed_response
+      request = build_put_request("#{worksheet_url}/#{record.id}", body: { "fields" => record.fields_for_update })
+      response = perform_request(request)
+      log_response(response, 'PUT')
+      result = parse_response(response)
 
-      check_and_raise_error(result, status_code: response.code)
+      check_and_raise_error(result, status_code: response.code.to_i)
 
       record.override_attributes!(result_attributes(result))
       record
-
     end
 
     def update_record_fields(record_id, fields_for_update)
-      response = self.class.patch(worksheet_url + "/" + record_id,
-        :body => { "fields" => fields_for_update }.to_json,
-        :headers => { "Content-type" => "application/json" })
-      log_request(response, 'PATCH')
-      result = response.parsed_response
+      request = build_patch_request("#{worksheet_url}/#{record_id}", body: { "fields" => fields_for_update })
+      response = perform_request(request)
+      log_response(response, 'PATCH')
+      result = parse_response(response)
 
-      check_and_raise_error(result, status_code: response.code)
+      check_and_raise_error(result, status_code: response.code.to_i)
 
       Record.new(result_attributes(result))
     end
 
     # Deletes record in table based on id
     def destroy(id)
-      response = self.class.delete(worksheet_url + "/" + id)
-      log_request(response, 'DELETE')
-      response.parsed_response
+      request = build_delete_request("#{worksheet_url}/#{id}")
+      response = perform_request(request)
+      log_response(response, 'DELETE')
+      result = parse_response(response)
+      check_and_raise_error(result, status_code: response.code.to_i)
+      result
     end
 
     protected
 
     def check_and_raise_error(response, status_code: nil)
-      response['error'] ? raise(Error.new(response['error'], status_code: status_code)) : false
+      return false unless response.is_a?(Hash) && response['error']
+
+      raise Error.new(response['error'], status_code: status_code)
     end
 
-    def log_request(response, http_method)
+    def log_response(response, http_method)
+      status_code = response.code.to_i
+
       if defined?(Rails)
-        Rails.logger.info("[Airtable] #{response.code} #{http_method} #{worksheet_name}")
+        Rails.logger.info("[Airtable] #{status_code} #{http_method} #{worksheet_name}")
       end
 
       if defined?(NewRelic::Agent)
         NewRelic::Agent.add_custom_attributes(
-          airtable_status_code: response.code,
+          airtable_status_code: status_code,
           airtable_table: worksheet_name,
           airtable_method: http_method
         )
         NewRelic::Agent.record_custom_event('AirtableRequest', {
-          status_code: response.code,
+          status_code: status_code,
           table: worksheet_name,
           http_method: http_method
         })
       end
+    end
+
+    def parse_response(response)
+      body = response.body
+      return {} if body.nil? || body.empty?
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      raise Error.new(
+        { 'type' => 'INVALID_RESPONSE', 'message' => "Unexpected response body: #{body[0..200]}" },
+        status_code: response.code.to_i
+      )
     end
 
     def result_attributes(res)
@@ -142,7 +159,7 @@ module Airtable
     end
 
     def worksheet_url
-      "/#{app_token}/#{url_encode(worksheet_name)}"
+      "#{BASE_PATH}/#{app_token}/#{url_encode(worksheet_name)}"
     end
 
     # From http://apidock.com/ruby/ERB/Util/url_encode
@@ -151,6 +168,6 @@ module Airtable
         sprintf("%%%02X", $&.unpack("C")[0])
       }
     end
-  end # Table
+  end
 
-end # Airtable
+end

--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -123,21 +123,30 @@ module Airtable
 
     def log_response(response, http_method)
       status_code = response.code.to_i
+      duration_ms = @last_request_duration_ms || 0
+      request_body_size = @last_request_body_size || 0
+      response_body_size = @last_response_body_size || 0
 
       if defined?(Rails)
-        Rails.logger.info("[Airtable] #{status_code} #{http_method} #{worksheet_name}")
+        Rails.logger.info("[Airtable] #{status_code} #{http_method} #{worksheet_name} #{duration_ms}ms request=#{request_body_size}b response=#{response_body_size}b")
       end
 
       if defined?(NewRelic::Agent)
         NewRelic::Agent.add_custom_attributes(
           airtable_status_code: status_code,
           airtable_table: worksheet_name,
-          airtable_method: http_method
+          airtable_method: http_method,
+          airtable_duration_ms: duration_ms,
+          airtable_request_body_size: request_body_size,
+          airtable_response_body_size: response_body_size
         )
         NewRelic::Agent.record_custom_event('AirtableRequest', {
           status_code: status_code,
           table: worksheet_name,
-          http_method: http_method
+          http_method: http_method,
+          duration_ms: duration_ms,
+          request_body_size: request_body_size,
+          response_body_size: response_body_size
         })
       end
     end

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -283,6 +283,73 @@ describe Airtable do
     end
   end
 
+  describe "instrumentation" do
+    it "should track request duration in milliseconds" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      table.find("rec123")
+      duration_ms = table.instance_variable_get(:@last_request_duration_ms)
+      assert_kind_of Integer, duration_ms
+      assert duration_ms >= 0, "duration_ms should be non-negative, got #{duration_ms}"
+    end
+
+    it "should track request body size for POST requests" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
+        { "fields" => { "name" => "Sarah" }, "id" => "rec1" }, :post)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:name => "Sarah")
+      table.create(record)
+      request_body_size = table.instance_variable_get(:@last_request_body_size)
+      assert request_body_size > 0, "request body size should be positive for POST, got #{request_body_size}"
+    end
+
+    it "should track response body size" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      table.find("rec123")
+      response_body_size = table.instance_variable_get(:@last_response_body_size)
+      assert response_body_size > 0, "response body size should be positive, got #{response_body_size}"
+    end
+
+    it "should track zero request body size for GET requests" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      table.find("rec123")
+      request_body_size = table.instance_variable_get(:@last_request_body_size)
+      assert_equal 0, request_body_size
+    end
+
+    it "should log connection retry with error details" do
+      call_count = 0
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_return do |_request|
+          call_count += 1
+          if call_count == 1
+            raise Errno::ECONNRESET
+          else
+            { body: { "fields" => { "name" => "Test" }, "id" => "rec123" }.to_json,
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' } }
+          end
+        end
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      table.find("rec123")
+
+      $stderr = original_stderr
+      assert_includes stderr_output.string, '[Airtable] Connection reset'
+      assert_includes stderr_output.string, 'Errno::ECONNRESET'
+      assert_includes stderr_output.string, 'retrying GET'
+    end
+  end
+
   describe "worksheet names with special characters" do
     it "should encode spaces in worksheet names" do
       sheet_name = "My Table"

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -23,19 +23,24 @@ describe Airtable do
     end
 
     it "should select records based on a formula" do
-      query_str = "OR(RECORD_ID() = 'recXYZ1', RECORD_ID() = 'recXYZ2', RECORD_ID() = 'recXYZ3', RECORD_ID() = 'recXYZ4')"
-      escaped_query = HTTParty::Request::NON_RAILS_QUERY_STRING_NORMALIZER.call(filterByFormula: query_str)
-      request_url = "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}?#{escaped_query}"
-      stub_airtable_response!(request_url, { "records" => []})
+      query_str = "OR(RECORD_ID() = 'recXYZ1', RECORD_ID() = 'recXYZ2')"
+      stub_request(:get, /https:\/\/api\.airtable\.com\/v0\/#{@app_key}\/#{@sheet_name}/)
+        .with(query: hash_including({ 'filterByFormula' => query_str }))
+        .to_return(
+          body: { "records" => [] }.to_json,
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
       @table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
       @select_records = @table.select(formula: query_str)
       assert_equal @select_records.records, []
     end
 
     it "should raise an ArgumentError if a formula is not a string" do
-      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}", { "records" => [], "offset" => "abcde" })
       @table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
-      proc {  @table.select(formula: {foo: 'bar'}) }.must_raise ArgumentError
+      assert_raises ArgumentError do
+        @table.select(formula: {foo: 'bar'})
+      end
     end
 
     it "should allow creating records" do

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -7,7 +7,7 @@ describe Airtable do
     @sheet_name = "Test"
   end
 
-  describe "with Airtable" do
+  describe "client" do
     it "should allow client to be created" do
       @client = Airtable::Client.new(@client_key)
       assert_kind_of Airtable::Client, @client
@@ -15,6 +15,19 @@ describe Airtable do
       assert_kind_of Airtable::Table, @table
     end
 
+    it "should accept a custom timeout" do
+      @client = Airtable::Client.new(@client_key, timeout: 10)
+      @table = @client.table(@app_key, @sheet_name)
+      assert_kind_of Airtable::Table, @table
+    end
+
+    it "should use the default timeout when none is specified" do
+      @table = Airtable::Table.new(@client_key, @app_key, @sheet_name)
+      assert_kind_of Airtable::Table, @table
+    end
+  end
+
+  describe "records" do
     it "should fetch record set" do
       stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}", { "records" => [], "offset" => "abcde" })
       @table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
@@ -22,6 +35,21 @@ describe Airtable do
       assert_equal "abcde", @records.offset
     end
 
+    it "should fetch records with sort options" do
+      stub_request(:get, /https:\/\/api\.airtable\.com\/v0\/#{@app_key}\/#{@sheet_name}/)
+        .with(query: hash_including({ 'sortField' => 'Name', 'sortDirection' => 'desc' }))
+        .to_return(
+          body: { "records" => [{ "fields" => { "Name" => "Alice" }, "id" => "rec1" }] }.to_json,
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      @table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      @records = @table.records(sort: ["Name", "desc"])
+      assert_equal 1, @records.records.length
+    end
+  end
+
+  describe "select" do
     it "should select records based on a formula" do
       query_str = "OR(RECORD_ID() = 'recXYZ1', RECORD_ID() = 'recXYZ2')"
       stub_request(:get, /https:\/\/api\.airtable\.com\/v0\/#{@app_key}\/#{@sheet_name}/)
@@ -42,7 +70,20 @@ describe Airtable do
         @table.select(formula: {foo: 'bar'})
       end
     end
+  end
 
+  describe "find" do
+    it "should find a record by id" do
+      record_id = "rec456"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "fields" => { "name" => "Found Record" }, "id" => record_id })
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = table.find(record_id)
+      assert_equal record_id, record["id"]
+    end
+  end
+
+  describe "create" do
     it "should allow creating records" do
       stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
         { "fields" => { "name" => "Sarah Jaine", "email" => "sarah@jaine.com", "foo" => "bar" }, "id" => "12345" }, :post)
@@ -52,27 +93,213 @@ describe Airtable do
       assert_equal "12345", record["id"]
       assert_equal "bar", record["foo"]
     end
+  end
 
-    it "should allow updating records" do
-        record_id = "12345"
-        stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
-          { "fields" => { "name" => "Sarah Jaine", "email" => "sarah@jaine.com", "foo" => "bar" }, "id" => record_id }, :put)
-        table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
-        record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => record_id)
-        table.update(record)
-        assert_equal "12345", record["id"]
-        assert_equal "bar", record["foo"]
+  describe "update" do
+    it "should allow updating records with PUT" do
+      record_id = "12345"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "fields" => { "name" => "Sarah Jaine", "email" => "sarah@jaine.com", "foo" => "bar" }, "id" => record_id }, :put)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => record_id)
+      table.update(record)
+      assert_equal "12345", record["id"]
+      assert_equal "bar", record["foo"]
     end
 
+    it "should allow patching record fields" do
+      record_id = "rec123"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "fields" => { "name" => "Updated Name" }, "id" => record_id }, :patch)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      result = table.update_record_fields(record_id, { "name" => "Updated Name" })
+      assert_equal record_id, result["id"]
+    end
+  end
+
+  describe "destroy" do
+    it "should allow deleting a record" do
+      record_id = "rec789"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "deleted" => true, "id" => record_id }, :delete)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      result = table.destroy(record_id)
+      assert_equal true, result["deleted"]
+    end
+
+    it "should raise an error when delete returns an error" do
+      record_id = "rec789"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "error" => { "type" => "NOT_FOUND", "message" => "Record not found" } }, :delete, 404)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      assert_raises Airtable::Error do
+        table.destroy(record_id)
+      end
+    end
+  end
+
+  describe "error handling" do
     it "should raise an error when the API returns an error" do
       stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
         {"error"=>{"type"=>"UNKNOWN_COLUMN_NAME", "message"=>"Could not find fields foo"}}, :post, 422)
       table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
       record = Airtable::Record.new(:foo => "bar")
-      assert_raises Airtable::Error do
-         table.create(record)
+      error = assert_raises Airtable::Error do
+        table.create(record)
+      end
+      assert_equal "UNKNOWN_COLUMN_NAME", error.type
+      assert_equal 422, error.status_code
+    end
+
+    it "should include the status code in errors" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
+        {"error"=>{"type"=>"INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", "message"=>"Invalid permissions"}}, :post, 403)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:foo => "bar")
+      error = assert_raises Airtable::Error do
+        table.create(record)
+      end
+      assert_equal 403, error.status_code
+      assert_equal "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", error.type
+    end
+
+    it "should raise an error for non-JSON response bodies" do
+      stub_request(:post, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}")
+        .to_return(
+          body: '<html>502 Bad Gateway</html>',
+          status: 502,
+          headers: { 'Content-Type' => 'text/html' }
+        )
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:foo => "bar")
+      error = assert_raises Airtable::Error do
+        table.create(record)
+      end
+      assert_equal "INVALID_RESPONSE", error.type
+      assert_equal 502, error.status_code
+    end
+
+    it "should return nil for empty response bodies on find" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_return(
+          body: '',
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      result = table.find("rec123")
+      assert_nil result
+    end
+
+    it "should return nil for nil response bodies on find" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_return(
+          body: nil,
+          status: 204,
+          headers: {}
+        )
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      result = table.find("rec123")
+      assert_nil result
+    end
+  end
+
+  describe "authorisation" do
+    it "should set authorisation header on requests" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .with(headers: { 'Authorization' => "Bearer #{@client_key}" })
+        .to_return(
+          body: { "fields" => { "name" => "Test" }, "id" => "rec123" }.to_json,
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+    end
+  end
+
+  describe "timeouts" do
+    it "should raise Net::OpenTimeout on connection timeout" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_timeout
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      assert_raises Net::OpenTimeout do
+        table.find("rec123")
       end
     end
 
-  end # describe Airtable
-end # Airtable
+    it "should raise Net::ReadTimeout on read timeout" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_raise(Net::ReadTimeout)
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      assert_raises Net::ReadTimeout do
+        table.find("rec123")
+      end
+    end
+  end
+
+  describe "connection resilience" do
+    it "should recover from a stale connection" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+    end
+
+    it "should retry once on connection reset" do
+      call_count = 0
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_return do |_request|
+          call_count += 1
+          if call_count == 1
+            raise Errno::ECONNRESET
+          else
+            { body: { "fields" => { "name" => "Test" }, "id" => "rec123" }.to_json,
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' } }
+          end
+        end
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+      assert_equal 2, call_count
+    end
+
+    it "should raise after retrying on persistent connection failure" do
+      stub_request(:get, "https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123")
+        .to_raise(Errno::ECONNRESET)
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      assert_raises Errno::ECONNRESET do
+        table.find("rec123")
+      end
+    end
+  end
+
+  describe "worksheet names with special characters" do
+    it "should encode spaces in worksheet names" do
+      sheet_name = "My Table"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/My%20Table/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, sheet_name)
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+    end
+
+    it "should encode ampersands in worksheet names" do
+      sheet_name = "Plans & Users"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/Plans%20%26%20Users/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+      table = Airtable::Client.new(@client_key).table(@app_key, sheet_name)
+      record = table.find("rec123")
+      assert_equal "rec123", record["id"]
+    end
+  end
+end

--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -4,18 +4,18 @@ describe Airtable do
   describe Airtable::Record do
     it "should not return id in fields_for_update" do
       record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
-      record.fields_for_update.wont_include(:id)
+      refute_includes record.fields_for_update.keys, :id
     end
 
     it "returns new columns in fields_for_update" do
       record = Airtable::Record.new(:name => "Sarah Jaine", :email => "sarah@jaine.com", :id => 12345)
       record[:website] = "http://sarahjaine.com"
-      record.fields_for_update.must_include(:website)
+      assert record.fields_for_update.key?(:website), "Expected fields_for_update to include :website"
     end
 
     it "returns fields_for_update in original capitalization" do
       record = Airtable::Record.new("Name" => "Sarah Jaine")
-      record.fields_for_update.must_include("Name")
+      assert_includes record.fields_for_update.keys, "Name"
     end
-  end # describe Record
-end # Airtable
+  end
+end


### PR DESCRIPTION
## Summary

- Remove the HTTParty dependency and use Ruby's built-in Net::HTTP directly
- Add persistent connections that reuse TCP/TLS across requests to the same host
- Add configurable timeout (default 30 seconds) for open, read, and write operations
- Harden response parsing to handle non-JSON, empty, and nil response bodies
- Add request-level instrumentation (duration, payload sizes) to Rails.logger and NewRelic
- Add connection lifecycle logging (opened, reconnected, closed) at debug level
- Add connection retry logging with error details at warn level
- Expand test coverage from 10 tests to 34 tests

## Context

Part of the Airtable sync investigation (Nude-Finance/MonoRepo#3566). Production benchmarks showed:

- **No timeout was configured**, defaulting to Ruby's 60 seconds. Workers hung for up to a minute on unresponsive calls.
- **Each request created a new TCP connection and TLS handshake.** Persistent connections are 26% faster in production.
- **Non-JSON responses (502 HTML pages) caused nil to propagate downstream**, leading to `NoMethodError: undefined method 'keys' for nil` — the most common error in our Sidekiq dead queue (194 occurrences).
- **29% of Airtable requests in the last 48 hours returned a 403 error** (38,000 out of 137,000). The `destroy` method silently swallowed these errors.
- **No request-level timing or payload size metrics** — New Relic could see that external calls to api.airtable.com were slow, but there was no way to break down latency by table or correlate slow calls with large payloads.

## Production benchmark

10 rounds alternating between both methods on the same Airtable base to ensure fair conditions:

| Round | New connection (HTTParty) | Persistent connection (Net::HTTP) |
|-------|-------------------------|------------------------------------|
| 1 | 7.24s | 8.73s |
| 2 | 9.33s | 3.15s |
| 3 | 14.11s | 4.64s |
| 4 | 9.59s | 31.55s |
| 5 | 15.07s | 2.68s |
| 6 | 8.88s | 4.99s |
| 7 | 2.36s | 3.20s |
| 8 | 5.65s | 1.66s |
| 9 | 14.94s | 3.92s |
| 10 | 12.17s | 8.64s |
| **Total** | **99.34s** | **73.16s** |
| **Average** | **9.93s** | **7.32s** |

**26.4% faster.** Over a full plan sync (12+ Airtable calls), that saves roughly 30 seconds per plan. With ~500 plans queued and only 2 workers, that adds up to hours of saved processing time.

## Commits

1. **Update development dependencies for Ruby 3.4 compatibility** — minitest 5.25, webmock 3.24, update deprecated test syntax. No behaviour change.
2. **Replace HTTParty with Net::HTTP for persistent connections** — the core change. Persistent connection with keep-alive, configurable timeout, automatic connection recovery on IOError/ECONNRESET/EPIPE/SSLError, hardened response parsing.
3. **Forward timeout parameter through Client** — `Client.new` now accepts an optional `timeout:` keyword argument.
4. **Add comprehensive test coverage** — 19 new tests covering timeouts, connection resilience, error handling, special characters, and more.
5. **Add request instrumentation, connection lifecycle logging, and retry visibility** — measure request duration (milliseconds), track request and response body sizes (bytes), log connection lifecycle events (opened/reconnected/closed) at debug level, log connection retries with full error details at warn level. All metrics forwarded to NewRelic custom attributes and AirtableRequest custom events for per-table latency dashboards.

## Observability added

### Log output (Rails.logger)

**Info level** — every request:
```
[Airtable] 200 PATCH Plans 18432ms request=1247b response=2891b
```

**Warn level** — connection retries:
```
[Airtable] Connection reset (Errno::ECONNRESET: Connection reset by peer), retrying GET Users
```

**Debug level** — connection lifecycle:
```
[Airtable] Connection opened for Plans
[Airtable] Connection reconnected for Plans
[Airtable] Connection closed for Plans
```

### NewRelic custom attributes (per transaction)

- `airtable_status_code` — HTTP status code (integer)
- `airtable_table` — Airtable table name
- `airtable_method` — HTTP method (GET, POST, PATCH, PUT, DELETE)
- `airtable_duration_ms` — request duration in milliseconds
- `airtable_request_body_size` — request payload size in bytes
- `airtable_response_body_size` — response payload size in bytes

### NewRelic AirtableRequest custom event

Same fields as above (`status_code`, `table`, `http_method`, `duration_ms`, `request_body_size`, `response_body_size`). Enables NRQL queries like:

```sql
SELECT average(duration_ms), percentile(duration_ms, 95)
FROM AirtableRequest
FACET table, http_method
SINCE 1 hour ago
```

## Backwards compatibility

The public interface is unchanged. All existing callers in the main application continue to work without modification. The only change needed in the main app is updating the gem `ref:` in the Gemfile.

## Test plan

- [x] All 34 tests passing, 53 assertions, 0 failures, 0 errors on Ruby 3.4.8
- [x] Reviewed by two independent code review agents for correctness, thread safety, and backwards compatibility
- [ ] Run the main application test suite with the gem pointed at this branch
- [ ] Test in staging with real Airtable calls before deploying to production