### PR TITLE
Add Airtable error type and message to request logging and NewRelic events

### DIFF
--- a/lib/airtable/table.rb
+++ b/lib/airtable/table.rb
@@ -24,8 +24,8 @@ module Airtable
       options["sortField"], options["sortDirection"] = options.delete(:sort) if options[:sort]
       request = build_get_request(worksheet_url, query: options)
       response = perform_request(request)
-      log_response(response, 'GET')
       result = parse_response(response)
+      log_response(response, 'GET', parsed_result: result)
       check_and_raise_error(result, status_code: response.code.to_i)
       RecordSet.new(result)
     end
@@ -46,8 +46,8 @@ module Airtable
 
       request = build_get_request(worksheet_url, query: options)
       response = perform_request(request)
-      log_response(response, 'GET')
       result = parse_response(response)
+      log_response(response, 'GET', parsed_result: result)
       check_and_raise_error(result, status_code: response.code.to_i)
       RecordSet.new(result)
     end
@@ -60,8 +60,8 @@ module Airtable
     def find(id)
       request = build_get_request("#{worksheet_url}/#{id}")
       response = perform_request(request)
-      log_response(response, 'GET')
       result = parse_response(response)
+      log_response(response, 'GET', parsed_result: result)
       check_and_raise_error(result, status_code: response.code.to_i)
       Record.new(result_attributes(result)) if result.present? && result["id"]
     end
@@ -70,8 +70,8 @@ module Airtable
     def create(record)
       request = build_post_request(worksheet_url, body: { "fields" => record.fields })
       response = perform_request(request)
-      log_response(response, 'POST')
       result = parse_response(response)
+      log_response(response, 'POST', parsed_result: result)
 
       check_and_raise_error(result, status_code: response.code.to_i)
 
@@ -83,8 +83,8 @@ module Airtable
     def update(record)
       request = build_put_request("#{worksheet_url}/#{record.id}", body: { "fields" => record.fields_for_update })
       response = perform_request(request)
-      log_response(response, 'PUT')
       result = parse_response(response)
+      log_response(response, 'PUT', parsed_result: result)
 
       check_and_raise_error(result, status_code: response.code.to_i)
 
@@ -95,8 +95,8 @@ module Airtable
     def update_record_fields(record_id, fields_for_update)
       request = build_patch_request("#{worksheet_url}/#{record_id}", body: { "fields" => fields_for_update })
       response = perform_request(request)
-      log_response(response, 'PATCH')
       result = parse_response(response)
+      log_response(response, 'PATCH', parsed_result: result)
 
       check_and_raise_error(result, status_code: response.code.to_i)
 
@@ -107,8 +107,8 @@ module Airtable
     def destroy(id)
       request = build_delete_request("#{worksheet_url}/#{id}")
       response = perform_request(request)
-      log_response(response, 'DELETE')
       result = parse_response(response)
+      log_response(response, 'DELETE', parsed_result: result)
       check_and_raise_error(result, status_code: response.code.to_i)
       result
     end
@@ -121,32 +121,45 @@ module Airtable
       raise Error.new(response['error'], status_code: status_code)
     end
 
-    def log_response(response, http_method)
+    def log_response(response, http_method, parsed_result: nil)
       status_code = response.code.to_i
       duration_ms = @last_request_duration_ms || 0
       request_body_size = @last_request_body_size || 0
       response_body_size = @last_response_body_size || 0
+      error_type = parsed_result&.dig('error', 'type')
+      error_message = parsed_result&.dig('error', 'message')
+
+      log_line = "[Airtable] #{status_code} #{http_method} #{worksheet_name} #{duration_ms}ms request=#{request_body_size}b response=#{response_body_size}b"
+      log_line += " error_type=#{error_type} error_message=#{error_message}" if error_type
 
       if defined?(Rails)
-        Rails.logger.info("[Airtable] #{status_code} #{http_method} #{worksheet_name} #{duration_ms}ms request=#{request_body_size}b response=#{response_body_size}b")
+        Rails.logger.info(log_line)
+      else
+        $stderr.puts(log_line)
       end
 
       if defined?(NewRelic::Agent)
-        NewRelic::Agent.add_custom_attributes(
+        attributes = {
           airtable_status_code: status_code,
           airtable_table: worksheet_name,
           airtable_method: http_method,
           airtable_duration_ms: duration_ms,
           airtable_request_body_size: request_body_size,
           airtable_response_body_size: response_body_size
-        )
+        }
+        attributes[:airtable_error_type] = error_type if error_type
+        attributes[:airtable_error_message] = error_message if error_message
+
+        NewRelic::Agent.add_custom_attributes(attributes)
         NewRelic::Agent.record_custom_event('AirtableRequest', {
           status_code: status_code,
           table: worksheet_name,
           http_method: http_method,
           duration_ms: duration_ms,
           request_body_size: request_body_size,
-          response_body_size: response_body_size
+          response_body_size: response_body_size,
+          error_type: error_type,
+          error_message: error_message
         })
       end
     end

--- a/test/airtable_test.rb
+++ b/test/airtable_test.rb
@@ -350,6 +350,117 @@ describe Airtable do
     end
   end
 
+  describe "error logging in responses" do
+    it "should include error_type and error_message in log output when Airtable returns an error" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
+        { "error" => { "type" => "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", "message" => "Invalid permissions, or the requested model was not found" } }, :post, 403)
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:name => "Test")
+
+      assert_raises Airtable::Error do
+        table.create(record)
+      end
+
+      $stderr = original_stderr
+      assert_includes stderr_output.string, 'error_type=INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND'
+      assert_includes stderr_output.string, 'error_message=Invalid permissions, or the requested model was not found'
+    end
+
+    it "should not include error fields in log output for successful responses" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "fields" => { "name" => "Test" }, "id" => "rec123" })
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      table.find("rec123")
+
+      $stderr = original_stderr
+      refute_includes stderr_output.string, 'error_type='
+      refute_includes stderr_output.string, 'error_message='
+    end
+
+    it "should include error details for GET requests returning 403" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/rec123",
+        { "error" => { "type" => "MODEL_ID_NOT_FOUND", "message" => "Could not find record" } }, :get, 403)
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+
+      assert_raises Airtable::Error do
+        table.find("rec123")
+      end
+
+      $stderr = original_stderr
+      assert_includes stderr_output.string, 'error_type=MODEL_ID_NOT_FOUND'
+    end
+
+    it "should include error details for PATCH requests with unknown columns" do
+      record_id = "rec123"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "error" => { "type" => "UNKNOWN_COLUMN_NAME", "message" => "Could not find fields Premium Type (protection)" } }, :patch, 422)
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+
+      assert_raises Airtable::Error do
+        table.update_record_fields(record_id, { "Premium Type (protection)" => "Life" })
+      end
+
+      $stderr = original_stderr
+      assert_includes stderr_output.string, 'error_type=UNKNOWN_COLUMN_NAME'
+      assert_includes stderr_output.string, 'error_message=Could not find fields Premium Type (protection)'
+    end
+
+    it "should include error details for DELETE requests on missing records" do
+      record_id = "rec789"
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}/#{record_id}",
+        { "error" => { "type" => "NOT_FOUND", "message" => "Record not found" } }, :delete, 404)
+
+      stderr_output = StringIO.new
+      original_stderr = $stderr
+      $stderr = stderr_output
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+
+      assert_raises Airtable::Error do
+        table.destroy(record_id)
+      end
+
+      $stderr = original_stderr
+      assert_includes stderr_output.string, 'error_type=NOT_FOUND'
+    end
+
+    it "should preserve the error type and message on the raised exception" do
+      stub_airtable_response!("https://api.airtable.com/v0/#{@app_key}/#{@sheet_name}",
+        { "error" => { "type" => "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", "message" => "Invalid permissions, or the requested model was not found" } }, :post, 403)
+
+      table = Airtable::Client.new(@client_key).table(@app_key, @sheet_name)
+      record = Airtable::Record.new(:name => "Test")
+
+      error = assert_raises Airtable::Error do
+        table.create(record)
+      end
+
+      assert_equal "INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND", error.type
+      assert_equal "Invalid permissions, or the requested model was not found", error.message
+      assert_equal 403, error.status_code
+    end
+  end
+
   describe "worksheet names with special characters" do
     it "should encode spaces in worksheet names" do
       sheet_name = "My Table"


### PR DESCRIPTION
## Summary

- Adds `error_type` and `error_message` from Airtable API error responses to both Rails log output and NewRelic instrumentation
- Reorders the request lifecycle so the response body is parsed before logging, making error details available at log time
- Adds stderr fallback for log output in non-Rails environments (consistent with existing retry/connection logging)

## Why

Following [Airtable support's recommendation](https://github.com/Nude-Finance/MonoRepo/issues/3583), we need to distinguish between different types of errors in Airtable API responses. After the recent Airtable cleanup (960k records deleted, 5 tables removed), we're seeing a high volume of 403 errors that could mean either:

- **Deleted record** (`INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND` or `MODEL_ID_NOT_FOUND`) — stale record IDs referencing deleted data
- **Actual permissions issue** (`INVALID_PERMISSIONS`) — a real problem that needs investigation
- **Schema mismatch** (`UNKNOWN_COLUMN_NAME`) — fields renamed or removed in Airtable

Currently our logging and NewRelic only capture the HTTP status code, so all 403s look the same. This change adds the error type and message so we can triage effectively.

## What changed

### `lib/airtable/table.rb`

1. **Reordered all Table methods** (`records`, `select`, `find`, `create`, `update`, `update_record_fields`, `destroy`) so `parse_response` runs before `log_response`. Previously the response was logged before parsing, so error details were not available.

2. **`log_response` now accepts `parsed_result:`** keyword argument. When the parsed result contains an `error` key, it extracts `error.type` and `error.message`.

3. **Rails log line** now includes `error_type=X error_message=Y` when an error is present. Successful responses are unchanged.

4. **NewRelic custom attributes** now include `airtable_error_type` and `airtable_error_message` on the current transaction (for error correlation).

5. **NewRelic custom events** (`AirtableRequest`) now include `error_type` and `error_message` fields (for NRQL querying).

6. **Added stderr fallback** for `log_response` when Rails is not defined, consistent with `log_retry` and `log_connection`.

### `test/airtable_test.rb`

Added 6 tests covering:
- Error type and message appear in log output for POST returning 403
- No error fields in log output for successful responses
- Error details for GET returning 403 (deleted record scenario)
- Error details for PATCH returning 422 (unknown column name scenario)
- Error details for DELETE returning 404 (record not found scenario)
- Error type, message, and status code preserved on the raised `Airtable::Error` exception

## After deploying

Errors can be queried in NewRelic with:

```sql
SELECT count(*) FROM AirtableRequest
WHERE error_type IS NOT NULL
FACET error_type, table, http_method
```

Example log output for an error response:
```
[Airtable] 403 POST Cases 12ms request=156b response=91b error_type=INVALID_PERMISSIONS_OR_MODEL_NOT_FOUND error_message=Invalid permissions, or the requested model was not found
```

## Test plan

- [x] All 40 existing tests pass (0 failures, 77 assertions)
- [x] 6 new tests verify error logging across all HTTP methods and error types
- [ ] After merging: deploy and verify error_type appears in NewRelic `AirtableRequest` events
- [ ] Confirm we can distinguish stale ID errors from permission errors in NewRelic dashboards