### PR TITLE
Bump default HTTP timeout from 30s to 52s

### DIFF
--- a/lib/airtable/resource.rb
+++ b/lib/airtable/resource.rb
@@ -6,7 +6,7 @@ module Airtable
   class Resource
     BASE_URI = 'https://api.airtable.com'
     BASE_PATH = '/v0'
-    DEFAULT_TIMEOUT = 30
+    DEFAULT_TIMEOUT = 52
 
     attr_reader :api_key, :app_token, :worksheet_name
 


### PR DESCRIPTION
## Summary

Increases `DEFAULT_TIMEOUT` from 30s to 52s to eliminate `Net::ReadTimeout` errors in production.

**Evidence from NewRelic (since last master commit, March 24):**
- 47,318 total Airtable requests from `SyncToAcreJob`
- 25 requests (0.05%) exceeded 30s
- Of those: p50=36s, p75=42s, p90=46s, p95=47s, max=51s
- 9 resulted in `Net::ReadTimeout` ([Sentry BACKEND-API-12C](https://tembo-s4.sentry.io/issues/6237389884/))

**Why 52s and not lower:** `SyncToAcreJob` runs with `retry: false` — if a request times out, it's lost with no retry. The max observed successful duration is 51s, so 52s ensures no viable requests are killed by the timeout.

## Change

`lib/airtable/resource.rb` line 9: `DEFAULT_TIMEOUT = 30` → `DEFAULT_TIMEOUT = 52`

After merging, update the gem ref in the main app's Gemfile.